### PR TITLE
Changes on layout and cross-OS compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3818,11 +3818,6 @@
       "resolved": "https://registry.npmjs.org/@react-native-community/geolocation/-/geolocation-1.4.2.tgz",
       "integrity": "sha512-9x9dHDeUXnh2larA4zTT3y/tXPmRnysh5o9fsNbGcnUKPj1BUCIHnGGPxEIDnwP1DNIMP2DN9DmuMHImtTbX6A=="
     },
-    "@react-native-community/picker": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/picker/-/picker-1.3.0.tgz",
-      "integrity": "sha512-ak4CU6IkpNmXeAt+A4stCr/GLAli/o+5NOREH2YxybBUY0Z8pyf+WPzDL5QQdl1DsyO8wsC5J1pnbrm9NAVKmQ=="
-    },
     "@react-navigation/core": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-3.5.1.tgz",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "@babel/runtime": "^7.7.2",
     "@react-native-community/eslint-config": "0.0.5",
-    "@react-native-community/picker": "^1.3.0",
     "@types/react-native-material-dropdown": "^0.11.4",
     "@types/use-global-hook": "^0.1.2",
     "axios": "^0.19.0",

--- a/src/elements/DropdownInput/DropdownInput.styles.ts
+++ b/src/elements/DropdownInput/DropdownInput.styles.ts
@@ -20,17 +20,17 @@ export default StyleSheet.create({
 		borderColor: 'transparent',
 	},
 	picker: {
-		height: 88,
+		// height: 88,
 		// bottom: 33,
-		backgroundColor: colors.LIGHT_YELLOW,
-		width: '100%',
-		flex: 1
+		// backgroundColor: colors.LIGHT_YELLOW,
+		// width: '100%',
+		// flex: 1,
 	},
 	pickerItemStyle: {
 		color: colors.NAVY_BLUE,
-		height: 88,
+		// height: 88,
 	},
 	textColor: {
-		color: colors.NAVY_BLUE
-	}
+		color: colors.NAVY_BLUE,
+	},
 });

--- a/src/elements/DropdownInput/DropdownInput.tsx
+++ b/src/elements/DropdownInput/DropdownInput.tsx
@@ -1,18 +1,21 @@
 import React, {
-	useState
+	useState,
 } from 'react';
-import { 
-	View, 
+import {
+	View,
 	Text,
-	Picker, 
+	Picker,
 	PickerProps,
 	StyleProp,
 	ViewStyle,
-	TouchableWithoutFeedback
+	TouchableWithoutFeedback,
+	Modal,
 } from 'react-native';
 import {
-	InputLabel
+	InputLabel,
+	Icon,
 } from '@elements';
+import { LIGHT_YELLOW } from '@util/colors';
 import styles from './DropdownInput.styles';
 
 interface DropdownInputProps {
@@ -22,57 +25,93 @@ interface DropdownInputProps {
 
 	label: string;
 
-	data?: [];
+	data?: Array<string>; // data is required
 
 	style?: StyleProp<ViewStyle>;
 }
 
 export const DropdownInput = ({
-			value,
-			setValue,
-			label,
-			// style,
-			data
-		}: DropdownInputProps) => {
+	value,
+	setValue,
+	label,
+	style,
+	data,
+}: DropdownInputProps) => {
+	const [ isPickerOpen, setIsPickerOpen ] = useState(false);
 
-			const [isPickerOpen, setIsPickerOpen] = useState(false)
+	const handleOnValueChange = (itemValue, itemIndex) => {
+		setValue(itemValue);
+	};
 
-			const handleOnValueChange = (itemValue, itemIndex) => {
-				setValue(itemValue)
-				setIsPickerOpen(!isPickerOpen)
-			}
+	const handlePress = () => {
+		setIsPickerOpen(!isPickerOpen);
+	};
 
-			const handlePress = () => {
-				setIsPickerOpen(!isPickerOpen)
-			}
+	return (
+		<View style={style}>
+			<InputLabel text={label} />
 
-			// let testData = ['WA', 'NY', 'NJ']
-	
-			return (
-				<View>
-					<InputLabel text={label} />
-						<View style={styles.dropdownInput}>
-							<TouchableWithoutFeedback onPress={handlePress}>
-								<Text style={styles.textColor}>{value}</Text>
-							</TouchableWithoutFeedback>
-						</View>
-						{
-							isPickerOpen && 
-								<View>
-									<Picker
-										style={styles.picker}
-										itemStyle={styles.pickerItemStyle}
-										selectedValue={value}
-										onValueChange={handleOnValueChange}>
-											{/* {testData.map(st => {
-												return <Picker.Item label={st} value={st} />
-											})} */}
-											{data && data.map(st => {
-												return <Picker.Item label={st} value={st} />
-											})}
-									</Picker>
-							</View>
-						}
+			<TouchableWithoutFeedback onPress={handlePress}>
+				<View style={[
+					styles.dropdownInput,
+					{
+						flexDirection: 'row',
+						justifyContent: 'space-between',
+					},
+				]}
+				>
+					<Text style={styles.textColor}>{value}</Text>
+
+					<Icon name="dropdown" size={18} />
 				</View>
-			)
-}
+			</TouchableWithoutFeedback>
+
+
+			<Modal
+				visible={isPickerOpen}
+				transparent={true}
+				onRequestClose={() => setIsPickerOpen(false)}
+			>
+				<View
+					style={{
+						flex: 1,
+					}}
+				>
+					<TouchableWithoutFeedback
+						onPress={() => { setIsPickerOpen(false); }}
+					>
+						<View
+							style={{
+								flex: 1,
+							}}
+						/>
+					</TouchableWithoutFeedback>
+
+					<View
+						style={{
+							// flex: 1,
+							width: '100%',
+							backgroundColor: LIGHT_YELLOW,
+							position: 'absolute',
+							bottom: 0,
+						}}
+					>
+						<Picker
+							style={[
+								styles.picker,
+								{
+								// height: 300,
+								},
+							]}
+							itemStyle={styles.pickerItemStyle}
+							selectedValue={value}
+							onValueChange={handleOnValueChange}
+						>
+							{data && data.map(st => <Picker.Item color="NAVY_BLUE" label={st} value={st} />)}
+						</Picker>
+					</View>
+				</View>
+			</Modal>
+		</View>
+	);
+};

--- a/src/elements/DropdownInput/DropdownInput.tsx
+++ b/src/elements/DropdownInput/DropdownInput.tsx
@@ -10,12 +10,13 @@ import {
 	ViewStyle,
 	TouchableWithoutFeedback,
 	Modal,
+	Platform,
 } from 'react-native';
 import {
 	InputLabel,
 	Icon,
 } from '@elements';
-import { LIGHT_YELLOW } from '@util/colors';
+import { LIGHT_YELLOW, WHITE_TRANSPARENT } from '@util/colors';
 import styles from './DropdownInput.styles';
 
 interface DropdownInputProps {
@@ -50,52 +51,9 @@ export const DropdownInput = ({
 	return (
 		<View style={style}>
 			<InputLabel text={label} />
-
-			<TouchableWithoutFeedback onPress={handlePress}>
-				<View style={[
-					styles.dropdownInput,
-					{
-						flexDirection: 'row',
-						justifyContent: 'space-between',
-					},
-				]}
-				>
-					<Text style={styles.textColor}>{value}</Text>
-
-					<Icon name="dropdown" size={18} />
-				</View>
-			</TouchableWithoutFeedback>
-
-
-			<Modal
-				visible={isPickerOpen}
-				transparent={true}
-				onRequestClose={() => setIsPickerOpen(false)}
-			>
-				<View
-					style={{
-						flex: 1,
-					}}
-				>
-					<TouchableWithoutFeedback
-						onPress={() => { setIsPickerOpen(false); }}
-					>
-						<View
-							style={{
-								flex: 1,
-							}}
-						/>
-					</TouchableWithoutFeedback>
-
-					<View
-						style={{
-							// flex: 1,
-							width: '100%',
-							backgroundColor: LIGHT_YELLOW,
-							position: 'absolute',
-							bottom: 0,
-						}}
-					>
+			{
+				Platform.OS === 'android' || Platform.OS === 'web'
+					? (
 						<Picker
 							style={[
 								styles.picker,
@@ -109,9 +67,80 @@ export const DropdownInput = ({
 						>
 							{data && data.map(st => <Picker.Item color="NAVY_BLUE" label={st} value={st} />)}
 						</Picker>
-					</View>
-				</View>
-			</Modal>
+					)
+					: (
+						<View>
+							<TouchableWithoutFeedback onPress={handlePress}>
+								<View style={[
+									styles.dropdownInput,
+									{
+										flexDirection: 'row',
+										justifyContent: 'space-between',
+									},
+								]}
+								>
+									<Text style={styles.textColor}>{value}</Text>
+
+									<Icon name="dropdown" size={18} />
+								</View>
+							</TouchableWithoutFeedback>
+
+							<Modal
+								visible={isPickerOpen}
+								transparent={true}
+								onRequestClose={() => setIsPickerOpen(false)}
+							>
+								<View
+									style={{
+										flex: 1,
+										backgroundColor: WHITE_TRANSPARENT,
+									}}
+								>
+									<TouchableWithoutFeedback
+										onPress={() => { setIsPickerOpen(false); }}
+									>
+										<View
+											style={{
+												flex: 1,
+											}}
+										/>
+									</TouchableWithoutFeedback>
+
+									<View
+										style={{
+											// flex: 1,
+											width: '100%',
+											backgroundColor: LIGHT_YELLOW,
+											position: 'absolute',
+											bottom: 0,
+										}}
+									>
+										<Picker
+											style={[
+												styles.picker,
+												{
+													// height: 300,
+												},
+											]}
+											itemStyle={styles.pickerItemStyle}
+											selectedValue={value}
+											onValueChange={handleOnValueChange}
+										>
+											{data && data.map(st => (
+												<Picker.Item
+													color="NAVY_BLUE"
+													label={st}
+													value={st}
+													key={st}
+												/>
+											))}
+										</Picker>
+									</View>
+								</View>
+							</Modal>
+						</View>
+					)
+			}
 		</View>
 	);
 };

--- a/src/screens/LoginScreen/LoginScreen.tsx
+++ b/src/screens/LoginScreen/LoginScreen.tsx
@@ -13,8 +13,10 @@ import {
 	Title,
 	LinkButton,
 	FormTextInput,
+	DropdownInput,
 } from '@elements';
 import { TouchableWithoutFeedback } from 'react-native-gesture-handler';
+import { SafeAreaView } from 'react-navigation';
 import styles from './LoginScreen.styles';
 
 export default () => {
@@ -50,63 +52,36 @@ export default () => {
 
 	const handleForgotPassword = () => { console.log('Handle forgot password.'); };
 
+	const [ val, setVal ] = useState();
+
+	const data = [
+		'1',
+		'2',
+		'3',
+		'4',
+		'5',
+	];
+
 	return (
-		<KeyboardAvoidingView style={styles.outerContainer} behavior="padding">
-			<View style={styles.header}>
-				{/* TODO: use ContentHeader component when available */}
-				<Title text={`banana \n${userIdentity}`} />
-			</View>
-
-			<ScrollView style={styles.bodyContainer} contentContainerStyle={styles.bodyContentContainer}>
-				<View
-					style={styles.form}
+		<SafeAreaView>
+			<KeyboardAvoidingView style={styles.outerContainer} behavior="padding">
+				<View style={{
+					position: 'relative',
+					justifyContent: 'center',
+					alignItems: 'center',
+				}}
 				>
-					<FormTextInput
-						label="email"
-						placeholder="info@bananaapp.org"
-						value={email}
-						setValue={setEmail}
-						style={styles.inputEmail}
-						onSubmitEditing={handleEmailInputSubmit}
-						autoCorrect={false}
-						enablesReturnKeyAutomatically={true}
-						autoCompleteType="username"
-						textContentType="username"
-						keyboardType="email-address"
-						returnKeyType="next"
-						blurOnSubmit={true} // Necessary to prevent focus from 'flickering'
+					<DropdownInput
+						label="test"
+						value={val || data[0]}
+						setValue={setVal}
+						data={data}
+						style={{
+							width: '30%',
+						}}
 					/>
-
-					<FormTextInput
-						label="password"
-						type="password"
-						value={password}
-						setValue={setPassword}
-						ref={passwordInputRef}
-						onSubmitEditing={handleLogin}
-						enablesReturnKeyAutomatically={true}
-						autoCompleteType="password"
-						returnKeyType="go"
-						blurOnSubmit={false}
-					/>
-
-					<View style={styles.forgotPassword}>
-						{/* View wrapper required to constrain clickable area of button */}
-						<TouchableWithoutFeedback
-							onPress={handleForgotPassword}
-						>
-							<Text style={styles.forgotPasswordText}>
-								Forgot Password?
-							</Text>
-						</TouchableWithoutFeedback>
-					</View>
 				</View>
-
-				<View style={styles.buttonContainer}>
-					<LinkButton text="Log In" onPress={handleLogin} />
-					<LinkButton text="Register" destination="RegistrationScreen" />
-				</View>
-			</ScrollView>
-		</KeyboardAvoidingView>
+			</KeyboardAvoidingView>
+		</SafeAreaView>
 	);
 };


### PR DESCRIPTION
Heyo,

Since I haven't used Picker before, I had to play with it in order to help you further. And during playing, I began to find solutions. The code isn't done and my contribution is dirty, but it's a start to how the structure might be in order to present and work as expected. Feel free to use whatever part of this code that you want, and don't feel the need to merge this PR in. If you want, you can just use the git diff feature to see my changes.

Apparently, `Picker` is the scroll wheel list on iOS, but on Android the `Picker` is the dropdown itself with a modal included. In order to accommodate, there has to be a different structure for each OS.

In order for the interaction and styling to better work on iOS, I used a Modal. In addition, some styling had to be removed on the Picker & Picker Item

When someone scrolls to a new item in the list, the value gets updated still but the picker list stays open now; this is better for accessiibility (e.g. partial finger control) because it doesn't close unnecessarily soon if a selection was made accidentally.

The Modal includes a clickable background that closes the Picker Modal. This design choice needs to be thought through though. Because, if a user is on a form and they already selected a dropdown item, then they try to select the next input in the form, the modal will close and the input they meant to press will not activate since their press only closed the modal.